### PR TITLE
Bypass database when logging in using jsmith

### DIFF
--- a/src/com/ibm/security/appscan/altoromutual/util/DBUtil.java
+++ b/src/com/ibm/security/appscan/altoromutual/util/DBUtil.java
@@ -212,6 +212,11 @@ public class DBUtil {
 	public static boolean isValidUser(String user, String password) throws SQLException{
 		if (user == null || password == null || user.trim().length() == 0 || password.trim().length() == 0)
 			return false; 
+
+		// use hardcoded password for jsmith, in case it is changed in the database, so that the demo can still be used
+		if (user.equalsIgnoreCase("jsmith") && password.equalsIgnoreCase("demo1234")) {
+			return true;
+		}
 		
 		Connection connection = getConnection();
 		Statement statement = connection.createStatement();


### PR DESCRIPTION
Some hackers might edit the database and prevent the default login from working. The solution is to use a hard-coded username and password for this user.