### PR TITLE
fix(db): synchronize login-path methods to prevent Derby race condition

### DIFF
--- a/src/com/ibm/security/appscan/altoromutual/util/DBUtil.java
+++ b/src/com/ibm/security/appscan/altoromutual/util/DBUtil.java
@@ -209,7 +209,7 @@ public class DBUtil {
 	 * @return true if valid user, false otherwise
 	 * @throws SQLException
 	 */
-	public static boolean isValidUser(String user, String password) throws SQLException{
+	public static synchronized boolean isValidUser(String user, String password) throws SQLException{
 		if (user == null || password == null || user.trim().length() == 0 || password.trim().length() == 0)
 			return false; 
 		
@@ -233,7 +233,7 @@ public class DBUtil {
 	 * @return user information
 	 * @throws SQLException
 	 */
-	public static User getUserInfo(String username) throws SQLException{
+	public static synchronized User getUserInfo(String username) throws SQLException{
 		if (username == null || username.trim().length() == 0)
 			return null; 
 		
@@ -267,7 +267,7 @@ public class DBUtil {
 	 * @return
 	 * @throws SQLException
 	 */
-	public static Account[] getAccounts(String username) throws SQLException{
+	public static synchronized Account[] getAccounts(String username) throws SQLException{
 		if (username == null || username.trim().length() == 0)
 			return null; 
 		


### PR DESCRIPTION
AltoroJ's `DBUtil` uses a singleton `Connection` to Apache Derby (embedded). Under concurrent servlet access (e.g., from security scanning tools or multiple browser tabs), multiple threads call `isValidUser()` → `getConnection()` → `createStatement()` simultaneously on the same Connection object.

This causes Derby to throw `ERROR XCL16: ResultSet not open. Operation 'next' not permitted` because one thread's statement execution invalidates another thread's open ResultSet before it can be read.

## Fix

Add `synchronized` to the three methods in the login flow (`isValidUser`, `getUserInfo`, `getAccounts`) to serialize database access on the class monitor. This prevents concurrent threads from interfering with each other's ResultSets while preserving the existing application behavior (including the intentional SQL injection vulnerabilities for demonstration purposes).

## Impact

- No functional changes to the application
- Login flow works correctly under concurrent access
- All existing SQL injection vulnerabilities remain intact for security testing demonstrations
